### PR TITLE
fix dust tx check

### DIFF
--- a/src/Generic/lib/transaction.ts
+++ b/src/Generic/lib/transaction.ts
@@ -245,5 +245,5 @@ export function isDustTransaction(tx: Transaction, account: Account) {
   if (paymentSummary.every(payment => payment.publicKeys.every(pubkey => pubkey === account.publicKey))) return false
 
   // native payment with dust amount
-  return paymentSummary[0].asset.getCode() === "XLM" && paymentSummary[0].balanceChange.abs() <= DUST_THRESHOLD
+  return paymentSummary[0].asset.getCode() === "XLM" && paymentSummary[0].balanceChange.abs().lte(DUST_THRESHOLD)
 }


### PR DESCRIPTION
The problem was in incorrect number comparison. Before the fix the check was done wrongly for numbers in e-notation (e.g. 1e-7)