### PR TITLE
fix error when signing tx requests with no replacements

### DIFF
--- a/src/TransactionRequest/components/TransactionRequestContent.tsx
+++ b/src/TransactionRequest/components/TransactionRequestContent.tsx
@@ -102,7 +102,10 @@ function TransactionRequestContent(props: TransactionRequestContentProps) {
         }
       }
 
-      const newTx = props.txStellarUri.replace(filledReplacements).getTransaction()
+      const newTx =
+        Object.keys(filledReplacements).length > 0
+          ? props.txStellarUri.replace(filledReplacements).getTransaction()
+          : props.txStellarUri.getTransaction()
       sendTransaction(newTx)
     } catch (error) {
       trackError(error)


### PR DESCRIPTION
When tx has no replacements (all the fields required for operation are set), the `TransactionStellarUri#replace` fails. We overcome this problem by skipping call to `replace` in this case.

Example of the case leading to error: https://t.me/c/2011632833/1783 (Sunce Wallet Chat in telegram). In this case everything is set (including the source account)