### PR TITLE
make status bar on Android transparent again

### DIFF
--- a/cordova/config/config.template
+++ b/cordova/config/config.template
@@ -104,7 +104,9 @@
     <preference name="resizeOnFullScreen" value="true" />
     <preference name="ShowSplashScreenSpinner" value="false" />
     <preference name="SplashScreenDelay" value="$SPLASH_SCREEN_DELAY" />
+    <preference name="FadeSplashScreen" value="false" />
     <preference name="SwiftVersion" value="5.0" />
     <preference name="scheme" value="app" />
     <preference name="hostname" value="localhost" />
+    <preference name="BackgroundColor" value="0xffd6a400" />
 </widget>


### PR DESCRIPTION


## Making the fix for status bar color

> I think setting FadeSplashScreen to false should fix the issue, the problem seems related to the splash animation and since the setting will remove the animation it should not cause the issue.

Source: https://github.com/apache/cordova-android/issues/1501#issuecomment-1837298708

## Dealing with splash screen default color (was flashing black for a few moments):

> **Added SplashScreenBackgroundColor Preference Support**
> 
> Added support for a general preference to be consistent across platforms for setting the splash screen background color.
> 
> The following order of priority is applied when it comes to the Cordova Android platform:
> 
> AndroidWindowSplashScreenBackground preference
> SplashScreenBackgroundColor preference
> BackgroundColor preference
> #ffffff hardcoded

Source: https://cordova.apache.org/announcements/2024/05/23/cordova-android-13.0.0.html