### PR TITLE
fix: "Unnamed Account" gets in the way during edit when account name becomes empty

### DIFF
--- a/src/Account/components/AccountHeaderCard.tsx
+++ b/src/Account/components/AccountHeaderCard.tsx
@@ -68,9 +68,7 @@ function AccountHeaderCard(props: Props) {
       ? ({ account: props.account as Account } as const)
       : ({ accountCreation: props.account as AccountCreation } as const)
 
-  // It should never happen that "Unnamed account" is used
-  // It is only added for the rare case that the user has renamed their account to "" which is prevented by now
-  const name = meta.account?.name || meta.accountCreation?.name || "Unnamed Account"
+  const name = meta.account?.name || meta.accountCreation?.name || ""
 
   const showingSettings = matchesRoute(router.location.pathname, routes.accountSettings("*"))
 


### PR DESCRIPTION
Now you are able to clear the name field completely during the edit. If you will try to save the empty name, the old name will be restored (this was already implemented before). If there is no old name — e.g. you are creating a new account — the wallet won't let you proceed

https://github.com/user-attachments/assets/d043adc1-e73a-4118-ba53-79d3e8484f61


Closes #74 