### PR TITLE
feat: allow adding addresses to saved from payment form

### DIFF
--- a/src/Payment/components/PaymentForm.tsx
+++ b/src/Payment/components/PaymentForm.tsx
@@ -408,7 +408,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
         <React.Suspense fallback={<ViewLoading />}>
           <SavedAddressesDialog
             testnet={props.testnet}
-            readonly={true}
+            readonly={false}
             onClose={() => setShowSavedAddresses(false)}
             onSelect={handleOnSavedAddressClick}
           />


### PR DESCRIPTION
If you send tokens and can't find your counterparty in the saved addresses you can now add it and use it right away

Closes #83

https://github.com/user-attachments/assets/35701fac-c7b1-4438-b565-35542ab51d7e

